### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/rubocop.yml
+++ b/.github/workflows/rubocop.yml
@@ -6,6 +6,10 @@
 # pulled from repo
 name: "Rubocop"
 
+permissions:
+  contents: read
+  security-events: write
+
 on:
   push:
     branches: [ "main" ]


### PR DESCRIPTION
Potential fix for [https://github.com/liamswan/brew-aermod/security/code-scanning/2](https://github.com/liamswan/brew-aermod/security/code-scanning/2)

To fix the issue, we need to add a `permissions` block to the workflow. This block should specify the least privileges required for the workflow to function correctly. Based on the workflow's functionality:
- `contents: read` is sufficient for most CI workflows, including checking out the repository.
- `security-events: write` is required for uploading SARIF output using `github/codeql-action/upload-sarif`.

The `permissions` block should be added at the root level of the workflow to apply to all jobs, as there is only one job (`rubocop`) in this workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
