### PR TITLE
Fix resource release handling

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,7 +117,7 @@ jobs:
               echo "Resource URLs in $formula_name:"
               for url in $resource_urls; do
                 echo "  Testing URL: $url"
-                if curl --output /dev/null --silent --head --fail "$url"; then
+                if curl --location --silent --head --fail "$url" > /dev/null; then
                   echo "  ✅ $url is accessible"
                 else
                   echo "  ❌ $url is NOT accessible (HTTP error)"

--- a/.github/workflows/weekly-version-check.yml
+++ b/.github/workflows/weekly-version-check.yml
@@ -518,6 +518,10 @@ jobs:
           
           # Copy the updated README for release assets
           cp README.md release_assets/README.md
+
+          # Include all existing downloads so older versions remain available
+          cp downloads/*.zip release_assets/ 2>/dev/null || true
+          cp checksums/*.sha256 release_assets/ 2>/dev/null || true
           
           # Process each component
           components=0


### PR DESCRIPTION
## Summary
- ensure curl follows redirects when verifying release URLs in CI
- include all download assets when creating releases so older versions remain available

## Testing
- `./scripts/test_and_audit_formulas.sh` *(fails: brew not found)*

------
https://chatgpt.com/codex/tasks/task_b_683c2ef2d310832bac01bafb22b27a5e